### PR TITLE
[CW-5976] read offsets from Kafka when join consumer group, sync retr…

### DIFF
--- a/lib/kafka/consumer.rb
+++ b/lib/kafka/consumer.rb
@@ -452,8 +452,6 @@ module Kafka
     end
 
     def join_group
-      old_generation_id = @group.generation_id
-
       @group.join
 
       # we observed duplicates after rebalance because

--- a/lib/kafka/transaction_manager.rb
+++ b/lib/kafka/transaction_manager.rb
@@ -17,8 +17,8 @@ module Kafka
       transactional: false,
       transactional_id: nil,
       transactional_timeout: DEFAULT_TRANSACTION_TIMEOUT,
-      retry_backoff: 100,
-      max_retries: 5
+      retry_backoff: 0.02,
+      max_retries: 50
     )
       @cluster = cluster
       @logger = TaggedLogger.new(logger)
@@ -286,8 +286,8 @@ module Kafka
       if @retry_counter > @max_retries
         raise e
       end
-      @logger.info("#{e.class.name}, sleeping #{@retry_backoff} , retrying...")
-      sleep @retry_backoff
+      @logger.info("#{e.class.name}, sleeping #{(@retry_counter * @retry_backoff)} seconds, retrying...")
+      sleep(@retry_counter * @retry_backoff)
       retry
     end
 

--- a/spec/consumer_spec.rb
+++ b/spec/consumer_spec.rb
@@ -366,8 +366,8 @@ describe Kafka::Consumer do
       context 'with subsequent group generations' do
         let(:generation_ids) { [1, 2] }
 
-        it 'removes local offsets for partitions it is no longer assigned' do
-          expect(offset_manager).to receive(:clear_offsets_excluding).with(reassigned_partitions)
+        it 'clears local offsets' do
+          expect(offset_manager).to receive(:clear_offsets)
 
           expect do
             consumer.each_message do |message|


### PR DESCRIPTION
[CW-5976](https://appen.atlassian.net/browse/CW-5976)
- clear offset memory buffers so consumer has to read offsets from Kafka every time it joins consumer group.
- sync retry handler code with native Java client. Now we start to sleep with 20 milliseconds as in Java client, then increase amount each time with 20 milliseconds.