### PR TITLE
[CW-5976] fix TxnOffsetCommitResponse decoding and send_offsets_to_txn

### DIFF
--- a/lib/kafka/protocol/txn_offset_commit_response.rb
+++ b/lib/kafka/protocol/txn_offset_commit_response.rb
@@ -1,17 +1,44 @@
 module Kafka
   module Protocol
     class TxnOffsetCommitResponse
+      class PartitionError
+        attr_reader :partition, :error_code
 
-      attr_reader :error_code
+        def initialize(partition:, error_code:)
+          @partition = partition
+          @error_code = error_code
+        end
+      end
 
-      def initialize(error_code:)
-        @error_code = error_code
+      class TopicPartitionsError
+        attr_reader :topic, :partitions
+
+        def initialize(topic:, partitions:)
+          @topic = topic
+          @partitions = partitions
+        end
+      end
+
+      attr_reader :errors
+
+      def initialize(errors:)
+        @errors = errors
       end
 
       def self.decode(decoder)
         _throttle_time_ms = decoder.int32
-        error_code = decoder.int16
-        new(error_code: error_code)
+        errors = decoder.array do
+          TopicPartitionsError.new(
+            topic: decoder.string,
+            partitions: decoder.array do
+              PartitionError.new(
+                partition: decoder.int32,
+                error_code: decoder.int16
+              )
+            end
+          )
+        end
+        new(errors: errors)
       end
     end
   end

--- a/lib/kafka/transaction_manager.rb
+++ b/lib/kafka/transaction_manager.rb
@@ -261,6 +261,11 @@ module Kafka
           end
         end
       end
+
+      nil
+    rescue
+      @transaction_state.transition_to!(TransactionStateMachine::ERROR)
+      raise
     end
 
     def in_transaction?

--- a/lib/kafka/transaction_manager.rb
+++ b/lib/kafka/transaction_manager.rb
@@ -248,14 +248,18 @@ module Kafka
       end
 
       retry_error_handler do
-        send_response = transaction_coordinator.txn_offset_commit(
+        send_response = group_coordinator(group_id: group_id).txn_offset_commit(
           transactional_id: @transactional_id,
           group_id: group_id,
           producer_id: @producer_id,
           producer_epoch: @producer_epoch,
           offsets: offsets
         )
-        Protocol.handle_error(send_response.error_code)
+        send_response.errors.each do |tp|
+          tp.partitions.each do |partition|
+            Protocol.handle_error(partition.error_code)
+          end
+        end
       end
     end
 
@@ -309,6 +313,12 @@ module Kafka
     def transaction_coordinator
       @cluster.get_transaction_coordinator(
         transactional_id: @transactional_id
+      )
+    end
+
+    def group_coordinator(group_id:)
+      @cluster.get_group_coordinator(
+        group_id: group_id
       )
     end
 


### PR DESCRIPTION
[CW-5976](https://appen.atlassian.net/browse/CW-5976)
- original gem has incorrect response handling of TxnOffsetCommit request. The response structure is the same as for AddPartitionsToTxn response.
- fix `TransactionManager#send_offsets_to_txn` method. According to native Java client, `TxnOffsetCommitRequest` should be sent from group coordinator, not transaction coordinator.

We weren't able to catch the error we have with group coordinator because TxnOffsetCommit response was handled incorrectly and we got 0 code.

These changes will be PRed to the original gem later. The code will be slightly different because they ignored our changes for retry_error_handler part.